### PR TITLE
Minor CSS fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -16,6 +16,7 @@
     
     -webkit-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
     -moz-box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
 }
 
 .wksp-header {


### PR DESCRIPTION
Just some small fixes to add a missing standard `box-shadow` property (`-webkit-box-shadow` has not been required since [Chrome 9](http://caniuse.com/css-boxshadow). but I left it in anyway), and stopped the link CSS from overriding the Brackets Core CSS. :)
