### PR TITLE
Use the correct link to the extension

### DIFF
--- a/WorkspacesPreferencesManager.js
+++ b/WorkspacesPreferencesManager.js
@@ -50,7 +50,7 @@ define(function (require, exports, module) {
         
         // Directory and File
         _baseDirectoryPath          = brackets.app.getApplicationSupportDirectory(),
-        _preferencesDirectoryPath   = _baseDirectoryPath + "/extensions/extensionsData/brackets-workspaces",
+        _preferencesDirectoryPath   = require.toUrl('./'), //_baseDirectoryPath + "/extensions/extensionsData/brackets-workspaces",
         _preferencesDirectory       = FileSystem.getDirectoryForPath(_preferencesDirectoryPath),
         _preferencesFilePath        = _preferencesDirectoryPath + "/preferences.json",
         _preferencesFile            = FileSystem.getFileForPath(_preferencesFilePath),

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "author": "thomasvalera <thomasvalera@gmail.com> (https://github.com/thomasvalera)",
     "license": "MIT",
     "engines": {
-        "brackets": ">=0.34.0"
+        "brackets": ">=0.41.0"
     }
 }


### PR DESCRIPTION
The extension is not necessarily at the path (in fact it's rather unlikely if you install it over the extension manager).
This meant it just throw an error cause it couldn't find the preferences.json (or create it).

I'm _not_ sure that this will fix #8 (seems to be a different error that I can't reproduce though) but it's now working fine for me on ubuntu with sprint 41 so maybe it's somehow connected.
